### PR TITLE
Sphinx theme skeleton

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 PyLadies
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,0 @@
-# doc-theme
-A PyLadies theme for docs that use Sphinx/Read the Docs

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,40 @@
+PyLadies Sphinx Theme
+=====================
+
+A PyLadies theme for docs that use Sphinx_/`Read the Docs`_.
+
+.. _Sphinx: http://sphinx-doc.org/
+.. _Read the Docs: https://readthedocs.org/
+
+
+How to use this theme
+---------------------
+
+To use this theme:
+
+#. Install the theme.
+   Run ``pip install pyladies_sphinx_theme``.
+
+#. Modify your Sphinx project's ``conf.py`` to use the theme:
+
+   * Import ``pyladies_sphinx_theme``.
+   * Add ``pyladies_sphinx_theme.get_path()`` to the ``html_theme_path`` list.
+   * Set ``html_theme`` to ``'pyladies_sphinx_theme'``.
+
+   Typically, ``conf.py`` will contain the following lines:
+
+   ::
+
+      import pyladies_sphinx_theme
+
+      html_theme_path = [pyladies_sphinx_theme.get_path()]
+
+      html_theme = 'pyladies_sphinx_theme'
+
+   If you want to use the theme with Read the Docs (or other automated build
+   tools), consider adding ``pyladies_sphinx_theme`` to your
+   ``requirements.txt`` or ``setup.py`` requirements.
+
+#. Rebuild your documentation (typically by running ``make html``).
+
+Now your documentation has a shiny new look.

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,7 @@ How to use this theme
 To use this theme:
 
 #. Install the theme.
-   Run ``pip install pyladies_sphinx_theme``.
+   Run ``pip install pyladies-sphinx-theme``.
 
 #. Modify your Sphinx project's ``conf.py`` to use the theme:
 

--- a/pyladies_sphinx_theme/__init__.py
+++ b/pyladies_sphinx_theme/__init__.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 PyLadies
+
 import os.path
 
 

--- a/pyladies_sphinx_theme/__init__.py
+++ b/pyladies_sphinx_theme/__init__.py
@@ -1,0 +1,6 @@
+import os.path
+
+
+def get_path():
+    """Return the path to this theme."""
+    return os.path.dirname(os.path.abspath(os.path.dirname(__file__)))

--- a/pyladies_sphinx_theme/theme.conf
+++ b/pyladies_sphinx_theme/theme.conf
@@ -1,6 +1,6 @@
 [theme]
 inherit = basic
-stylesheet = style.css
+stylesheet = css/style.css
 pygments_style = stylename
 
 [options]

--- a/pyladies_sphinx_theme/theme.conf
+++ b/pyladies_sphinx_theme/theme.conf
@@ -1,0 +1,7 @@
+[theme]
+inherit = basic
+stylesheet = style.css
+pygments_style = stylename
+
+[options]
+# pyladies_is_rad = true

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ with codecs.open(readme_path, encoding='utf-8') as f:
 
 
 setup(
-    name='pyladies_sphinx_theme',
+    name='pyladies-sphinx-theme',
     version='0.1.dev0',
     description='A PyLadies theme for Sphinx',
     long_description=long_description,

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,50 @@
+import codecs
+import os.path
+
+from setuptools import setup
+
+readme_path = os.path.join(os.path.dirname(__file__), 'README.rst')
+
+with codecs.open(readme_path, encoding='utf-8') as f:
+    long_description = f.read()
+
+
+setup(
+    name='pyladies_sphinx_theme',
+
+    version='0.1.dev0',
+
+    description='A PyLadies theme for Sphinx',
+    long_description=long_description,
+
+    url='https://github.com/pyladies/doc-theme',
+
+    author='PyLadies',
+
+    license='MIT',
+
+    classifiers=[
+        'Development Status :: 3 - Alpha',
+        'Framework :: Sphinx :: Theme',
+        'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
+        'Topic :: Documentation :: Sphinx',
+        'Topic :: Documentation',
+        'Topic :: Software Development :: Documentation',
+    ],
+
+    keywords='pyladies sphinx theme documentation docs',
+
+    packages=['pyladies_sphinx_theme'],
+
+    install_requires=['sphinx'],
+
+    package_data={'pyladies_sphinx_theme': [
+        'theme.conf',
+        '*.html',
+        'static/css/*.css',
+    ]},
+
+    zip_safe=False,
+)

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,6 @@
+# -*- coding: utf-8 -*-
+# Copyright (c) 2015 PyLadies
+
 import codecs
 import os.path
 

--- a/setup.py
+++ b/setup.py
@@ -11,18 +11,12 @@ with codecs.open(readme_path, encoding='utf-8') as f:
 
 setup(
     name='pyladies_sphinx_theme',
-
     version='0.1.dev0',
-
     description='A PyLadies theme for Sphinx',
     long_description=long_description,
-
     url='https://github.com/pyladies/doc-theme',
-
     author='PyLadies',
-
     license='MIT',
-
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Framework :: Sphinx :: Theme',
@@ -33,18 +27,13 @@ setup(
         'Topic :: Documentation',
         'Topic :: Software Development :: Documentation',
     ],
-
     keywords='pyladies sphinx theme documentation docs',
-
     packages=['pyladies_sphinx_theme'],
-
     install_requires=['sphinx'],
-
     package_data={'pyladies_sphinx_theme': [
         'theme.conf',
         '*.html',
         'static/css/*.css',
     ]},
-
     zip_safe=False,
 )


### PR DESCRIPTION
This PR adds a skeleton for a pip-installable theme that I worked on during the sprints at PyCon 2015. Highlights:
- Added an MIT license file
- Switched the README to reStructuredText to support eventual inclusion on PyPI
- Substantiated the README with installation instructions
- Added a `pyladies_sphinx_theme` package (I think there was a mention of a PyLadies namespace, so I imagine this will change along with other metadata)

I'm open to feedback or changes to make this better. Thanks!
